### PR TITLE
Add frontend startup commands to Makefile

### DIFF
--- a/Project/backend/Makefile
+++ b/Project/backend/Makefile
@@ -49,7 +49,7 @@ migrate:
 
 build-dev:
 	DOCKER_BUILDKIT=1 COMPOSE_DOCKER_CLI_BUILD=1 $(DOCKER_COMPOSE) -f docker-compose.yml up --build -d
-
+	@cd ../frontend &&  sudo npm install && sudo npm run dev
 
 stop-dev:
 	@$(DOCKER_COMPOSE) -f docker-compose.yml down


### PR DESCRIPTION
## Description
<!-- Describe the changes made in this pull request -->
* Updated `build-dev` in the Makefile to include commands for starting the frontend:

1. Navigating to the frontend directory.
2. Installing frontend dependencies.
3. Starting the frontend development server.

## Related Backlog Item
<!-- Link to the specific backlog item this pull request addresses. -->
Issue: #

---

### Context
<!-- Why are these changes necessary? -->
* Frontend dependencies are installed using `sudo`.


---

## Checklist:
- [x] I have documented my changes
- [x] I have tested the changes and they work as expected
- [ ] I have assigned this PR to someone
- [ ] I have run `make format` to format my code

### Additional references