### PR TITLE
fix(page-number): Add 1 to `page_number`

### DIFF
--- a/Project/backend/codebase/graph_creator/services/netx_graphdb.py
+++ b/Project/backend/codebase/graph_creator/services/netx_graphdb.py
@@ -36,6 +36,8 @@ class NetXGraphDB:
 
             chunk_id = edge["chunk_id"]
             page_number = chunk_to_page[int(chunk_id)]
+            if isinstance(page_number, int):
+                page_number += 1
 
             # Add nodes with page attribute
             if edge["node_1"] not in graph:


### PR DESCRIPTION
## Description
* Add 1 to page number so it is more user friendly  

## Related Backlog Item
<!-- Link to the specific backlog item this pull request addresses. -->
Issue: #182

---

### Context
* In metadata page number is indexed from 0 but for the user we want it in a more friendly way.


---

## Checklist:
- [ ] I have documented my changes
- [X] I have tested the changes and they work as expected
- [X] I have assigned this PR to someone
- [ ] I have run `make format` to format my code

### Additional references

