### PR TITLE
Feat/minimize topics legend

### DIFF
--- a/Project/frontend/src/components/Graph_page/Legend.tsx
+++ b/Project/frontend/src/components/Graph_page/Legend.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
-import { Box } from '@mui/material';
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 type ITopicColourMap = Record<string, string>;
 
@@ -9,11 +16,8 @@ const Legend: React.FC<{ topicColorMap: ITopicColourMap }> = ({
   return (
     <Box
       sx={{
-        padding: '16px',
-        backgroundColor: '#121826',
         borderRadius: '10px',
         color: 'white',
-        maxHeight: '250px',
         overflowY: 'auto',
         // maxWidth: '300px',
         position: 'absolute',
@@ -22,40 +26,60 @@ const Legend: React.FC<{ topicColorMap: ITopicColourMap }> = ({
         zIndex: 1300,
       }}
     >
-      <Box component="ul" sx={{ padding: 0, margin: 0, listStyle: 'none' }}>
-        {Object.entries(topicColorMap).map(([topic, color]) => (
+      <Accordion
+        sx={{
+          backgroundColor: '#0d1117',
+          color: 'white',
+        }}
+      >
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon style={{ color: '#fff' }} />}
+        >
+          <Typography>Topic / Color Legend</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
           <Box
-            component="li"
-            key={topic}
             sx={{
-              display: 'flex',
-              marginBottom: '8px',
+              maxHeight: '250px',
+              overflowY: 'auto',
             }}
           >
-            <Box
-              sx={{
-                width: '20px',
-                height: '20px',
-                backgroundColor: color,
-                marginRight: '8px',
-                flexShrink: 0,
-              }}
-            />
-            <Box
-              component="span"
-              sx={{
-                fontSize: '0.875rem',
-                wordWrap: 'break-word',
-                whiteSpace: 'normal',
-                // maxWidth: '250px',
-                overflowWrap: 'break-word',
-              }}
-            >
-              {topic.substring(topic.indexOf('_') + 1)}
+            <Box component="ul">
+              {Object.entries(topicColorMap).map(([topic, color]) => (
+                <Box
+                  component="li"
+                  key={topic}
+                  sx={{
+                    display: 'flex',
+                    marginBottom: '8px',
+                  }}
+                >
+                  <Box
+                    sx={{
+                      width: '20px',
+                      height: '20px',
+                      backgroundColor: color,
+                      marginRight: '8px',
+                      flexShrink: 0,
+                    }}
+                  />
+                  <Box
+                    component="span"
+                    sx={{
+                      fontSize: '0.875rem',
+                      wordWrap: 'break-word',
+                      whiteSpace: 'normal',
+                      overflowWrap: 'break-word',
+                    }}
+                  >
+                    {topic.substring(topic.indexOf('_') + 1)}
+                  </Box>
+                </Box>
+              ))}
             </Box>
           </Box>
-        ))}
-      </Box>
+        </AccordionDetails>
+      </Accordion>
     </Box>
   );
 };

--- a/Project/frontend/src/components/Graph_page/Legend.tsx
+++ b/Project/frontend/src/components/Graph_page/Legend.tsx
@@ -15,11 +15,11 @@ const Legend: React.FC<{ topicColorMap: ITopicColourMap }> = ({
         color: 'white',
         maxHeight: '250px',
         overflowY: 'auto',
-        maxWidth: '500px',
+        // maxWidth: '300px',
         position: 'absolute',
         left: '16px',
         top: '16px',
-        zIndex: 1300, // Sicherstellen, dass die Legende nicht verdeckt wird
+        zIndex: 1300,
       }}
     >
       <Box component="ul" sx={{ padding: 0, margin: 0, listStyle: 'none' }}>
@@ -38,11 +38,21 @@ const Legend: React.FC<{ topicColorMap: ITopicColourMap }> = ({
                 height: '20px',
                 backgroundColor: color,
                 marginRight: '8px',
+                flexShrink: 0,
               }}
             />
-            <span style={{ fontSize: '0.875rem' }}>
+            <Box
+              component="span"
+              sx={{
+                fontSize: '0.875rem',
+                wordWrap: 'break-word',
+                whiteSpace: 'normal',
+                // maxWidth: '250px',
+                overflowWrap: 'break-word',
+              }}
+            >
               {topic.substring(topic.indexOf('_') + 1)}
-            </span>
+            </Box>
           </Box>
         ))}
       </Box>

--- a/Project/frontend/src/components/Graph_page/Legend.tsx
+++ b/Project/frontend/src/components/Graph_page/Legend.tsx
@@ -19,7 +19,7 @@ const Legend: React.FC<{ topicColorMap: ITopicColourMap }> = ({
         borderRadius: '10px',
         color: 'white',
         overflowY: 'auto',
-        // maxWidth: '300px',
+        maxWidth: '350px',
         position: 'absolute',
         left: '16px',
         top: '16px',


### PR DESCRIPTION
## Description
<!-- Describe the changes made in this pull request -->
* Made the topic-color legend minimized using the Accordion component. 

## Related Backlog Item
<!-- Link to the specific backlog item this pull request addresses. -->
Issue: #179 

---

### Context
<!-- Why are these changes necessary? -->
* To not make the graph visualization page filled with information. 


---

## Checklist:
- [ ] I have documented my changes
- [ ] I have tested the changes and they work as expected
- [ ] I have assigned this PR to someone
- [ ] I have run `make format` to format my code

### Additional references

